### PR TITLE
🐞fix: Minor bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folly-systems/custom-react-player",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple and lightweight video player component that helps you customize controls for your videos.",
   "main": "./dist/lib/index.js",
   "module": "./dist/es/index.js",

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -155,7 +155,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 
       <div
         className={styles.sliderHandle}
-        style={{ left: `${progressPercentage}%` }}
+        style={{ left: `${progressPercentage - 1}%` }}
         onClick={(ev) => {
           // On click of handle do nothing
           // stopPropagation is added here to avoid bubbling of this event and triggering parent elements click event

--- a/src/styles/ProgressBar.module.css
+++ b/src/styles/ProgressBar.module.css
@@ -11,6 +11,7 @@
   width: 100%;
   height: 4px;
   background-color: rgba(248, 248, 250, 0.3);
+  outline: none;
 }
 
 .sliderProgressBar {
@@ -36,7 +37,7 @@
   background: white;
   position: absolute;
   cursor: pointer;
-  transform: translateY(calc(-50% + (var(--size) / 4)));
+  transform: translateY(calc(-50% + 2px));
   visibility: hidden;
   transition: visibility 0.5s ease-out;
 }

--- a/src/styles/VideoPlayer.module.css
+++ b/src/styles/VideoPlayer.module.css
@@ -93,6 +93,7 @@
   display: flex;
   justify-content: center;
   cursor: pointer;
+  outline: none;
 }
 
 .playerIcon:hover {
@@ -114,6 +115,8 @@
 .timeSection {
   color: white;
   user-select: none;
+  -webkit-user-select: none; /* Chrome/Safari */
+  -moz-user-select: none;
   font-family: 'Open Sans', sans-serif;
 }
 


### PR DESCRIPTION
Safari:
1. Remove outline for video controls.
2. Disable text selection for the video time.

Video Slider:
1. Centre align the video player slider handle.